### PR TITLE
Fix panic in WriteHTML with empty metrics

### DIFF
--- a/calcs.go
+++ b/calcs.go
@@ -11,7 +11,9 @@ import (
 // Calc summarizes Tachymeter sample data
 // and returns it in the form of a *Metrics.
 func (m *Tachymeter) Calc() *Metrics {
-	metrics := &Metrics{}
+	metrics := &Metrics{
+		Histogram: &Histogram{},
+	}
 	if atomic.LoadUint64(&m.Count) == 0 {
 		return metrics
 	}

--- a/timeline_test.go
+++ b/timeline_test.go
@@ -1,0 +1,32 @@
+package tachymeter_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/jamiealquiza/tachymeter"
+)
+
+func TestTimelineEmptyMetrics(t *testing.T) {
+	tmp, err := ioutil.TempDir("", t.Name())
+	if err != nil {
+		t.Fatal("TempDir failed: ", err)
+	}
+	defer os.RemoveAll(tmp)
+
+	tline := &tachymeter.Timeline{}
+
+	ta := tachymeter.New(&tachymeter.Config{Size: 30})
+	m := ta.Calc()
+
+	tline.AddEvent(m)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("WriteHtml panicked: %v", r)
+		}
+	}()
+
+	tline.WriteHTML(tmp)
+}


### PR DESCRIPTION
`Timeline.WriteHTML` panicked if no metrics have been added via `AddTime`.

Fix this and add a test to verify new behaviour.