### PR TITLE
Clean HTML stuff, add Timeline.WriteHTMLTo

### DIFF
--- a/htmltemplate.go
+++ b/htmltemplate.go
@@ -1,12 +1,6 @@
 package tachymeter
 
-const (
-	tab string = `	`
-	nl  string = "\n"
-)
-
-var (
-	head = `<!doctype html>
+const head = `<!doctype html>
 <html>
 
 <head>
@@ -52,26 +46,18 @@ var (
 
 </head>
 <body>
-
 `
 
-	container = `
-
-	<div class="graph">
-        <canvas id="canvas-XCANVASID"></canvas>
-    </div>`
-
-	graph = `
-
+const graph = `
 	<script>
-	var ctx = document.getElementById("canvas-XCANVASID");
+	var ctx = document.getElementById("canvas-{{.CanvasID}}");
 	var myChart = new Chart(ctx, {
 	    type: 'bar',
 	    data: {
-	        labels: XKEYS,
+	        labels: {{.Keys}},
 	        datasets: [{
 	            label: 'Events',
-	            data: XVALUES,
+	            data: {{.Values}},
 	            backgroundColor: "rgba(49, 77, 114, 0.76)"
 	        }]
 	    },
@@ -86,10 +72,6 @@ var (
 	    }
 	});
 	</script>
-
 `
 
-	tail = "</body>\n</html>"
-
-	template = head + container + graph + tail
-)
+const tail = "</body>\n</html>"

--- a/timeline.go
+++ b/timeline.go
@@ -1,13 +1,13 @@
 package tachymeter
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
+	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
+	"text/template"
 	"time"
 )
 
@@ -33,6 +33,11 @@ func (t *Timeline) AddEvent(m *Metrics) {
 	})
 }
 
+const (
+	tab string = `	`
+	nl  string = "\n"
+)
+
 // WriteHTML takes an absolute path p and writes an
 // html file to 'p/tachymeter-<timestamp>.html' of all
 // histograms held by the *Timeline, in series.
@@ -41,46 +46,54 @@ func (t *Timeline) WriteHTML(p string) error {
 	if err != nil {
 		return err
 	}
-	var b bytes.Buffer
+	fname := fmt.Sprintf("%s/tachymeter-%d.html", path, time.Now().Unix())
+	f, err := os.Create(fname)
+	if err != nil {
+		return fmt.Errorf("can't create %s: %v", fname, err)
+	}
+	defer f.Close()
 
-	b.WriteString(head)
+	return t.WriteHTMLTo(f)
+}
+
+// WriteHTMLTo ...
+func (t *Timeline) WriteHTMLTo(w io.Writer) error {
+	_, err := io.WriteString(w, head)
+	if err != nil {
+		return err
+	}
 
 	// Append graph + info entry for each timeline
 	// event.
 	for n := range t.timeline {
 		// Graph div.
-		b.WriteString(fmt.Sprintf(`%s<div class="graph">%s`, tab, nl))
-		b.WriteString(fmt.Sprintf(`%s%s<canvas id="canvas-%d"></canvas>%s`, tab, tab, n, nl))
-		b.WriteString(fmt.Sprintf(`%s</div>%s`, tab, nl))
+		fmt.Fprintf(w, `%s<div class="graph">%s`, tab, nl)
+		fmt.Fprintf(w, `%s%s<canvas id="canvas-%d"></canvas>%s`, tab, tab, n, nl)
+		fmt.Fprintf(w, `%s</div>%s`, tab, nl)
 		// Info div.
-		b.WriteString(fmt.Sprintf(`%s<div class="info">%s`, tab, nl))
-		b.WriteString(fmt.Sprintf(`%s<p><h2>Iteration %d</h2>%s`, tab, n+1, nl))
-		b.WriteString(t.timeline[n].Metrics.String())
-		b.WriteString(fmt.Sprintf("%s%s</p></div>%s", nl, tab, nl))
+		fmt.Fprintf(w, `%s<div class="info">%s`, tab, nl)
+		fmt.Fprintf(w, `%s<p><h2>Iteration %d</h2>%s`, tab, n+1, nl)
+		fmt.Fprintf(w, t.timeline[n].Metrics.String())
+		fmt.Fprintf(w, "%s%s</p></div>%s", nl, tab, nl)
 	}
 
 	// Write graphs.
 	for id, m := range t.timeline {
-		s := genGraphHTML(m, id)
-		b.WriteString(s)
+		err := genGraphHTML(w, m, id)
+		if err != nil {
+			return fmt.Errorf("can't generate graph.js: %v", err)
+		}
 	}
 
-	b.WriteString(tail)
-
-	// Write file.
-	d := []byte(b.String())
-	fname := fmt.Sprintf("%s/tachymeter-%d.html", path, time.Now().Unix())
-	err = ioutil.WriteFile(fname, d, 0644)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	_, err = io.WriteString(w, head)
+	return err
 }
 
+var graphTmpl = template.Must(template.New("graph").Parse(graph))
+
 // genGraphHTML takes a *timelineEvent and id (used for each graph
-// html element ID) and creates a chart.js graph output.
-func genGraphHTML(te *timelineEvent, id int) string {
+// html element ID) and writes a chart.js graph into w.
+func genGraphHTML(w io.Writer, te *timelineEvent, id int) error {
 	keys := []string{}
 	values := []uint64{}
 
@@ -94,9 +107,17 @@ func genGraphHTML(te *timelineEvent, id int) string {
 	keysj, _ := json.Marshal(keys)
 	valuesj, _ := json.Marshal(values)
 
-	out := strings.Replace(graph, "XCANVASID", strconv.Itoa(id), 1)
-	out = strings.Replace(out, "XKEYS", string(keysj), 1)
-	out = strings.Replace(out, "XVALUES", string(valuesj), 1)
-
-	return out
+	err := graphTmpl.Execute(w, struct {
+		CanvasID string
+		Keys     string
+		Values   string
+	}{
+		CanvasID: strconv.Itoa(id),
+		Keys:     string(keysj),
+		Values:   string(valuesj),
+	})
+	if err != nil {
+		return fmt.Errorf("can't execute graph template: %v", err)
+	}
+	return nil
 }

--- a/timeline_test.go
+++ b/timeline_test.go
@@ -1,0 +1,35 @@
+package tachymeter_test
+
+import (
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/jamiealquiza/tachymeter"
+)
+
+func newTestTachy() *tachymeter.Tachymeter {
+	ta := tachymeter.New(&tachymeter.Config{Size: 4})
+
+	for i := 12; i < 16; i++ {
+		ta.AddTime(time.Duration(i) * time.Millisecond)
+	}
+	return ta
+}
+
+func BenchmarkWriteHTMLTo(b *testing.B) {
+	ta := newTestTachy()
+	tl := tachymeter.Timeline{}
+	tl.AddEvent(ta.Calc())
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	w := ioutil.Discard
+
+	for i := 0; i < b.N; i++ {
+		err := tl.WriteHTMLTo(w)
+		if err != nil {
+			b.Fatalf("can't write html: %s", err)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #32

`Timeline.WriteHTMLTo` takes a `io.Writer` so that it can directly
be used in various cases, for example directly passing an
http.ResponseWriter. Using a writer, many allocations are removed
by directly formatting the output with `fmt.Fprint`, remove the
`bytes.Buffer. as well.

Use a `text/template` for HTML generation. An `html/template` are
very similar but escapes the strings, and it was not playing
well the JSON marshaling of graph labels, also it is not based on
user input so no risk of code injection.

`genGraphHTML` also takes a writer to eliminate more copies.

Modify `Timeline.WriteHTML` to keep backward compatibility but
make it use WriteHTMLTo under the hood.

Add `BenchmarkWriteHTMLTo`. In the following benchmarks, `old` is
a version of `WriteHTMLTo` equivalent to original `WriteHTML`
code, present in current master, whereas `new` is this commit.

    name           old time/op    new time/op    delta
    WriteHTMLTo-8    25.4µs ±12%     7.0µs ± 3%  -72.49%  (p=0.008 n=5+5)

    name           old alloc/op   new alloc/op   delta
    WriteHTMLTo-8     161kB ± 0%       1kB ± 0%  -99.37%  (p=0.008 n=5+5)

    name           old allocs/op  new allocs/op  delta
    WriteHTMLTo-8      56.0 ± 0%      50.0 ± 0%  -10.71%  (p=0.008 n=5+5)