### PR TITLE
Change struct alignment to work on both 32 and 64 bit OS

### DIFF
--- a/tachymeter.go
+++ b/tachymeter.go
@@ -25,10 +25,10 @@ type Config struct {
 // Tachymeter holds event durations
 // and counts.
 type Tachymeter struct {
+	Count    uint64
 	sync.Mutex
 	Size     uint64
 	Times    timeSlice
-	Count    uint64
 	WallTime time.Duration
 	HBins    int
 }


### PR DESCRIPTION
The original structure leads to panic during atomic operations on 32 bit systems:

```
Aug 29 10:00:34 : goroutine 222 [running]:
Aug 29 10:00:34 : runtime/internal/atomic.Load64(0x394185ec, 0x6db6db, 0x0)
Aug 29 10:00:34 :    /usr/local/go/src/runtime/internal/atomic/asm_386.s:194 +0xb
```
